### PR TITLE
August Pie Security Patch

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -564,7 +564,7 @@
                 <action android:name="com.android.phone.CallFeaturesSetting.ADD_VOICEMAIL" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:priority="1000">
                 <action android:name="android.telephony.action.CONFIGURE_VOICEMAIL" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>


### PR DESCRIPTION
The android.telephony.action.CONFIGURE_VOICEMAIL intent is only handled
by the platform, so setting an intent filter priority here will ensure
that no other app can claim to handle it.

Test: Used test app which attempts to handle the intent to verify no
intent disambiguation dialog is shown and platform handles.
Bug: 185126149
Merged-In: I1c1b800737db5397d3e600e30c12ed2c8fc8efd9
Change-Id: I1c1b800737db5397d3e600e30c12ed2c8fc8efd9
(cherry picked from commit 5cd723c11bfe29dd44e7fcdc730c945d7348f3b6)